### PR TITLE
Hiding keyboard earlier if user clicks suggestion to prevent flicker

### DIFF
--- a/persistentsearchview/src/main/java/org/cryse/widget/persistentsearch/PersistentSearchView.java
+++ b/persistentsearchview/src/main/java/org/cryse/widget/persistentsearch/PersistentSearchView.java
@@ -696,6 +696,7 @@ public class PersistentSearchView extends RevealViewGroup {
             @Override
             public void onItemClick(AdapterView<?> arg0, View arg1, int arg2,
                                     long arg3) {
+                hideKeyboard();
                 SearchItem result = mSearchSuggestions.get(arg2);
                 setSearchString(result.getValue(), true);
                 fromEditingToSearch(true, false);
@@ -715,12 +716,11 @@ public class PersistentSearchView extends RevealViewGroup {
             showClearButton();
         }
         if (openKeyboard) {
-            if(showCustomKeyboard && mCustomKeyboardView != null) {
+            if(showCustomKeyboard && mCustomKeyboardView != null) { // Show custom keyboard
                 mCustomKeyboardView.setVisibility(View.VISIBLE);
                 mCustomKeyboardView.setEnabled(true);
-                ((InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE)).hideSoftInputFromWindow(getApplicationWindowToken(), 0);
 
-                //Enable cursor, but still prevent default keyboard from showing up
+                // Enable cursor, but still prevent default keyboard from showing up
                 OnTouchListener otl = new OnTouchListener() {
                     @Override
                     public boolean onTouch(View v, MotionEvent event) {
@@ -733,7 +733,7 @@ public class PersistentSearchView extends RevealViewGroup {
                                 int offset = layout.getOffsetForHorizontal(0, x);
                                 if (offset > 0)
                                     if (x > layout.getLineMax(0))
-                                        mSearchEditText.setSelection(offset);     // touch was at the end of the text
+                                        mSearchEditText.setSelection(offset);     // Touch was at the end of the text
                                     else
                                         mSearchEditText.setSelection(offset - 1);
                                 break;
@@ -743,7 +743,7 @@ public class PersistentSearchView extends RevealViewGroup {
                                 offset = layout.getOffsetForHorizontal(0, x);
                                 if (offset > 0)
                                     if (x > layout.getLineMax(0))
-                                        mSearchEditText.setSelection(offset);     // Touchpoint was at the end of the text
+                                        mSearchEditText.setSelection(offset);     // Touch point was at the end of the text
                                     else
                                         mSearchEditText.setSelection(offset - 1);
                                 break;
@@ -752,7 +752,7 @@ public class PersistentSearchView extends RevealViewGroup {
                     }
                 };
                 mSearchEditText.setOnTouchListener(otl);
-            } else {
+            } else { // Show default keyboard
                 mSearchEditText.setOnTouchListener(null);
                 InputMethodManager inputMethodManager = (InputMethodManager) getContext()
                         .getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -777,13 +777,16 @@ public class PersistentSearchView extends RevealViewGroup {
             mSearchListener.onSearchEditClosed();
         showMicButton();
 
-        InputMethodManager inputMethodManager = (InputMethodManager) getContext()
-                .getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputMethodManager.hideSoftInputFromWindow(getApplicationWindowToken(),
-                0);
-        if(mCustomKeyboardView != null) {
+        hideKeyboard();
+    }
+
+    private void hideKeyboard() {
+        if(showCustomKeyboard && mCustomKeyboardView != null) {
             mCustomKeyboardView.setVisibility(View.GONE);
             mCustomKeyboardView.setEnabled(false);
+        }
+        else {
+            ((InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE)).hideSoftInputFromWindow(getApplicationWindowToken(), 0);
         }
     }
 


### PR DESCRIPTION
If a user clicked on a suggestion using the suggestion builder and had
something anchored to the bottom (snackbar/floating action button) that displayed during onSearch() of the searchview, it would display on top of the keyboard and then flicker to the bottom of the screen once the keyboard dismissed. By causing the dismiss to happen during onClick of a suggestion, there is no flicker for the snackbar or floating action button.

Note: this only happened when clicking an item from the suggestion builder. Doing a regular search seemed to work just fine.
